### PR TITLE
Small fixes to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ git clone https://github.com/ccdawson2/roster-client.git
 cd roster-client
 npm install
 bower install
+npm install -g nodemon
 npm start
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This application accesses the following API's;
 ```shell
 git clone https://github.com/ccdawson2/roster-client.git
 cd roster-client
-npm install --save
-bower install --save
+npm install
+bower install
 npm start
 ```


### PR DESCRIPTION
- Remove '--save' switches in README instructions
   - The '--save' switch is used to save a package to package.json or bower.json when you first install a package from the command line. It is not needed when you are just installing already saved packages.

- Add instruction to install nodemon to README
    - Some people don't have it installed globally.